### PR TITLE
feat(cli): add BYOC commands — register, unregister, status

### DIFF
--- a/packages/apps/app-store-cli/src/commands/byoc/byoc.commands.ts
+++ b/packages/apps/app-store-cli/src/commands/byoc/byoc.commands.ts
@@ -1,0 +1,16 @@
+import type { Command } from 'commander';
+import { registerByocRegisterCommand } from './register.command.js';
+import { registerByocUnregisterCommand } from './unregister.command.js';
+import { registerByocStatusCommand } from './status.command.js';
+
+export function registerByocCommands(program: Command) {
+  const byocCmd = program
+    .command('byoc')
+    .description(
+      'Bring Your Own Canister — register externally-deployed canisters with Prometheus for discovery.',
+    );
+
+  registerByocRegisterCommand(byocCmd);
+  registerByocUnregisterCommand(byocCmd);
+  registerByocStatusCommand(byocCmd);
+}

--- a/packages/apps/app-store-cli/src/commands/byoc/register.command.ts
+++ b/packages/apps/app-store-cli/src/commands/byoc/register.command.ts
@@ -1,0 +1,63 @@
+import path from 'path';
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+import { registerExternalCanister } from '@prometheus-protocol/ic-js';
+import {
+  getCurrentIdentityName,
+  loadDfxIdentity,
+} from '../../identity.node.js';
+
+import type { Command } from 'commander';
+
+export function registerByocRegisterCommand(program: Command) {
+  program
+    .command('register <canister-id> [namespace]')
+    .description(
+      'Register an externally-deployed canister with the Prometheus registry for discovery.',
+    )
+    .action(async (canisterId: string, namespace: string | undefined) => {
+      // Resolve namespace from prometheus.yml if not provided
+      let targetNamespace = namespace;
+      if (!targetNamespace) {
+        const configPath = path.join(process.cwd(), 'prometheus.yml');
+        if (fs.existsSync(configPath)) {
+          const manifest = yaml.load(
+            fs.readFileSync(configPath, 'utf-8'),
+          ) as { namespace?: string };
+          targetNamespace = manifest?.namespace;
+        }
+      }
+
+      if (!targetNamespace) {
+        console.error(
+          '\n❌ Namespace is required. Provide it as an argument or run from a directory with prometheus.yml.',
+        );
+        process.exit(1);
+      }
+
+      try {
+        const currentIdentityName = getCurrentIdentityName();
+        const identity = loadDfxIdentity(currentIdentityName);
+
+        console.log(`\n🔗 Registering external canister...`);
+        console.log(`   Namespace:  ${targetNamespace}`);
+        console.log(`   Canister:   ${canisterId}`);
+        console.log(`   Identity:   ${currentIdentityName}`);
+
+        const binding = await registerExternalCanister(identity, {
+          namespace: targetNamespace,
+          canisterId,
+        });
+
+        console.log(`\n🎉 External canister registered successfully!`);
+        console.log(`   Namespace:  ${binding.namespace}`);
+        console.log(`   Canister:   ${binding.canisterId}`);
+        console.log(`   Bound by:   ${binding.boundBy}`);
+      } catch (error) {
+        console.error('\n❌ Registration failed:');
+        console.error(error);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/apps/app-store-cli/src/commands/byoc/status.command.ts
+++ b/packages/apps/app-store-cli/src/commands/byoc/status.command.ts
@@ -1,0 +1,57 @@
+import path from 'path';
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+import { getExternalBinding } from '@prometheus-protocol/ic-js';
+
+import type { Command } from 'commander';
+
+export function registerByocStatusCommand(program: Command) {
+  program
+    .command('status [namespace]')
+    .description(
+      'Check the BYOC external binding status for a namespace.',
+    )
+    .action(async (namespace: string | undefined) => {
+      // Resolve namespace from prometheus.yml if not provided
+      let targetNamespace = namespace;
+      if (!targetNamespace) {
+        const configPath = path.join(process.cwd(), 'prometheus.yml');
+        if (fs.existsSync(configPath)) {
+          const manifest = yaml.load(
+            fs.readFileSync(configPath, 'utf-8'),
+          ) as { namespace?: string };
+          targetNamespace = manifest?.namespace;
+        }
+      }
+
+      if (!targetNamespace) {
+        console.error(
+          '\n❌ Namespace is required. Provide it as an argument or run from a directory with prometheus.yml.',
+        );
+        process.exit(1);
+      }
+
+      try {
+        console.log(`\n🔍 Checking external binding for "${targetNamespace}"...\n`);
+
+        const binding = await getExternalBinding(targetNamespace);
+
+        if (!binding) {
+          console.log(`   No external canister bound to "${targetNamespace}".`);
+          return;
+        }
+
+        console.log(`   Namespace:  ${binding.namespace}`);
+        console.log(`   Canister:   ${binding.canisterId}`);
+        console.log(`   Bound by:   ${binding.boundBy}`);
+        console.log(
+          `   Bound at:   ${new Date(Number(binding.boundAt / BigInt(1_000_000))).toISOString()}`,
+        );
+      } catch (error) {
+        console.error('\n❌ Status check failed:');
+        console.error(error);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/apps/app-store-cli/src/commands/byoc/unregister.command.ts
+++ b/packages/apps/app-store-cli/src/commands/byoc/unregister.command.ts
@@ -1,0 +1,61 @@
+import path from 'path';
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+import { unregisterExternalCanister } from '@prometheus-protocol/ic-js';
+import {
+  getCurrentIdentityName,
+  loadDfxIdentity,
+} from '../../identity.node.js';
+
+import type { Command } from 'commander';
+
+export function registerByocUnregisterCommand(program: Command) {
+  program
+    .command('unregister <canister-id> [namespace]')
+    .description(
+      'Remove an external canister binding from the Prometheus registry.',
+    )
+    .action(async (canisterId: string, namespace: string | undefined) => {
+      // Resolve namespace from prometheus.yml if not provided
+      let targetNamespace = namespace;
+      if (!targetNamespace) {
+        const configPath = path.join(process.cwd(), 'prometheus.yml');
+        if (fs.existsSync(configPath)) {
+          const manifest = yaml.load(
+            fs.readFileSync(configPath, 'utf-8'),
+          ) as { namespace?: string };
+          targetNamespace = manifest?.namespace;
+        }
+      }
+
+      if (!targetNamespace) {
+        console.error(
+          '\n❌ Namespace is required. Provide it as an argument or run from a directory with prometheus.yml.',
+        );
+        process.exit(1);
+      }
+
+      try {
+        const currentIdentityName = getCurrentIdentityName();
+        const identity = loadDfxIdentity(currentIdentityName);
+
+        console.log(`\n🔗 Unregistering external canister...`);
+        console.log(`   Namespace:  ${targetNamespace}`);
+        console.log(`   Canister:   ${canisterId}`);
+        console.log(`   Identity:   ${currentIdentityName}`);
+
+        await unregisterExternalCanister(identity, {
+          namespace: targetNamespace,
+          canisterId,
+        });
+
+        console.log(`\n🎉 External canister unregistered successfully!`);
+        console.log(`   Namespace "${targetNamespace}" is now unbound.`);
+      } catch (error) {
+        console.error('\n❌ Unregistration failed:');
+        console.error(error);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/apps/app-store-cli/src/index.ts
+++ b/packages/apps/app-store-cli/src/index.ts
@@ -26,6 +26,7 @@ import { registerCanisterCommands } from './commands/canister/canister.commands.
 import { registerControllerCommands } from './commands/controller/controller.commands.js';
 import { registerVersionCommands } from './commands/version/version.commands.js';
 import { registerAppBountiesCommand } from './commands/app-bounties/app-bounties.commands.js';
+import { registerByocCommands } from './commands/byoc/byoc.commands.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -142,7 +143,10 @@ registerCanisterCommands(program); // Assuming you create a parent for register,
 registerControllerCommands(program); // Assuming you create a parent for add, remove, list
 registerVersionCommands(program); // Assuming you create a parent for list, deprecate
 
-// 5. App Bounties Commands (Related to application-specific bounties)
+// 5. BYOC (Bring Your Own Canister) Commands
+registerByocCommands(program);
+
+// 6. App Bounties Commands (Related to application-specific bounties)
 registerAppBountiesCommand(program);
 
 // 6. Leaderboard Commands (Related to leaderboards)

--- a/packages/canisters/mcp_registry/src/main.mo
+++ b/packages/canisters/mcp_registry/src/main.mo
@@ -85,6 +85,31 @@ shared (deployer) actor class ICRC118WasmRegistryCanister<system>(
   // Key: wasm_id, Value: Set of bounty_ids that reported divergence
   stable var divergence_progress = BTree.init<Text, [Nat]>(null);
 
+  // --- BYOC (Bring Your Own Canister) ---
+  // External canister bindings: namespace -> ExternalBinding
+  type ExternalBinding = {
+    canister_id : Principal;
+    namespace : Text;
+    bound_by : Principal;
+    bound_at : Nat;
+  };
+
+  type RegisterExternalRequest = {
+    namespace : Text;
+    canister_id : Principal;
+  };
+
+  type RegisterExternalError = {
+    #NotController;
+    #NamespaceNotFound;
+    #AlreadyBound;
+    #CanisterAlreadyBound;
+  };
+
+  stable var external_bindings = BTree.init<Text, ExternalBinding>(null);
+  // Reverse index: canister_id (text) -> namespace, for uniqueness enforcement
+  stable var canister_to_namespace = BTree.init<Text, Text>(null);
+
   // Constants for majority consensus
   let REQUIRED_VERIFIERS : Nat = 9; // Total verifiers needed
   let MAJORITY_THRESHOLD : Nat = 5; // Minimum successful verifications (5 of 9)
@@ -1683,6 +1708,104 @@ shared (deployer) actor class ICRC118WasmRegistryCanister<system>(
         return #ok(isController);
       };
     };
+  };
+
+  // =====================================================================================
+  // BYOC (Bring Your Own Canister) — External Deployment Registration
+  // =====================================================================================
+
+  /// Register an externally-deployed canister with the registry.
+  /// Caller must be a controller of the namespace.
+  /// Enforces strict 1:1 — one canister per namespace, one namespace per canister.
+  public shared (msg) func register_external_canister(req : RegisterExternalRequest) : async {
+    #ok : ExternalBinding;
+    #err : RegisterExternalError;
+  } {
+    let caller = msg.caller;
+    let state = icrc118wasmregistry().state;
+
+    // 1. Namespace must exist
+    switch (BTree.get(state.canister_types, Text.compare, req.namespace)) {
+      case (null) { return #err(#NamespaceNotFound) };
+      case (?canister_type) {
+        // 2. Caller must be a controller of the namespace
+        let isController = Option.isSome(
+          Array.find(
+            canister_type.controllers,
+            func(c : Principal) : Bool { Principal.equal(c, caller) },
+          )
+        );
+        if (not isController) { return #err(#NotController) };
+      };
+    };
+
+    // 3. Check namespace isn't already bound
+    switch (BTree.get(external_bindings, Text.compare, req.namespace)) {
+      case (?_) { return #err(#AlreadyBound) };
+      case (null) {};
+    };
+
+    // 4. Check canister isn't already bound to another namespace
+    let canisterText = Principal.toText(req.canister_id);
+    switch (BTree.get(canister_to_namespace, Text.compare, canisterText)) {
+      case (?_) { return #err(#CanisterAlreadyBound) };
+      case (null) {};
+    };
+
+    // 5. Create the binding
+    let binding : ExternalBinding = {
+      canister_id = req.canister_id;
+      namespace = req.namespace;
+      bound_by = caller;
+      bound_at = Int.abs(Time.now());
+    };
+
+    ignore BTree.insert(external_bindings, Text.compare, req.namespace, binding);
+    ignore BTree.insert(canister_to_namespace, Text.compare, canisterText, req.namespace);
+
+    return #ok(binding);
+  };
+
+  /// Unregister an external canister binding.
+  /// Caller must be a controller of the namespace.
+  public shared (msg) func unregister_external_canister(namespace : Text, canister_id : Principal) : async {
+    #ok;
+    #err : Text;
+  } {
+    let caller = msg.caller;
+    let state = icrc118wasmregistry().state;
+
+    // 1. Caller must be a controller of the namespace
+    switch (BTree.get(state.canister_types, Text.compare, namespace)) {
+      case (null) { return #err("Namespace not found") };
+      case (?canister_type) {
+        let isController = Option.isSome(
+          Array.find(
+            canister_type.controllers,
+            func(c : Principal) : Bool { Principal.equal(c, caller) },
+          )
+        );
+        if (not isController) { return #err("Not a controller of this namespace") };
+      };
+    };
+
+    // 2. Remove the binding
+    switch (BTree.get(external_bindings, Text.compare, namespace)) {
+      case (null) { return #err("No external binding for this namespace") };
+      case (?binding) {
+        if (not Principal.equal(binding.canister_id, canister_id)) {
+          return #err("Canister ID does not match the binding");
+        };
+        ignore BTree.delete(external_bindings, Text.compare, namespace);
+        ignore BTree.delete(canister_to_namespace, Text.compare, Principal.toText(canister_id));
+        return #ok;
+      };
+    };
+  };
+
+  /// Query the external binding for a namespace, if any.
+  public query func get_external_binding(namespace : Text) : async ?ExternalBinding {
+    BTree.get(external_bindings, Text.compare, namespace);
   };
 
   // The outcome of a DAO-led verification process.

--- a/packages/declarations/src/generated/mcp_registry/index.d.ts
+++ b/packages/declarations/src/generated/mcp_registry/index.d.ts
@@ -3,9 +3,9 @@ import type {
   HttpAgentOptions,
   ActorConfig,
   Agent,
-} from "@dfinity/agent";
-import type { Principal } from "@dfinity/principal";
-import type { IDL } from "@dfinity/candid";
+} from "@icp-sdk/core/agent";
+import type { Principal } from "@icp-sdk/core/principal";
+import type { IDL } from "@icp-sdk/core/candid";
 
 import { _SERVICE } from './mcp_registry.did';
 

--- a/packages/declarations/src/generated/mcp_registry/index.js
+++ b/packages/declarations/src/generated/mcp_registry/index.js
@@ -1,4 +1,4 @@
-import { Actor, HttpAgent } from "@dfinity/agent";
+import { Actor, HttpAgent } from "@icp-sdk/core/agent";
 
 // Imports and re-exports candid interface
 import { idlFactory } from "./mcp_registry.did.js";

--- a/packages/declarations/src/generated/mcp_registry/mcp_registry.did
+++ b/packages/declarations/src/generated/mcp_registry/mcp_registry.did
@@ -127,6 +127,18 @@ type Tip =
    last_block_index: blob;
  };
 type Timestamp = nat64;
+type TimerId = nat;
+type TimerDiagnostics = 
+ record {
+   currentTime: Time;
+   lastExecutionDelta: int;
+   lockStatus: opt Time;
+   nextExecutionDelta: opt int;
+   overdueActions: nat;
+   pendingActions: nat;
+   systemTimerStatus: opt TimerId;
+   totalActions: nat;
+ };
 type Time__1 = int;
 type Time = nat;
 type SupportedStandard = 
@@ -180,6 +192,28 @@ type Result =
  variant {
    err: TreasuryError;
    ok: nat;
+ };
+type RegisterExternalRequest = 
+ record {
+   canister_id: principal;
+   namespace: text;
+ };
+type RegisterExternalError = 
+ variant {
+   AlreadyBound;
+   CanisterAlreadyBound;
+   NamespaceNotFound;
+   NotController;
+ };
+type ReconstitutionTrace = 
+ record {
+   actionsRestored: nat;
+   errors: vec text;
+   migratedFrom: text;
+   migratedTo: text;
+   timersRestored: nat;
+   timestamp: Time;
+   validationPassed: bool;
  };
 type ManageControllerResult = 
  variant {
@@ -399,6 +433,13 @@ type ICRC118WasmRegistryCanister =
    ///    * @returns A status message indicating how many apps were successfully indexed.
    bootstrap_search_index: () -> (Result_5);
    can_install_wasm: (caller: principal, wasm_id: text) -> (bool) query;
+   cancel_actions_by_filter: (filter: ActionFilter) -> (CancellationResult);
+   cancel_actions_by_ids: (ids: vec nat) -> (CancellationResult);
+   clear_reconstitution_traces: () -> ();
+   emergency_clear_all_timers: () -> (nat);
+   force_release_lock: () -> (opt Time__1);
+   force_system_timer_cancel: () -> (bool);
+   get_actions_by_filter: (filter: ActionFilter) -> (vec ActionDetail) query;
    /// * Fetches and assembles all data for an app's detail page using its stable namespace.
    ///    * This is the single, powerful query the frontend needs.
    get_app_details_by_namespace: (namespace: text, opt_wasm_id: opt text) ->
@@ -416,6 +457,11 @@ type ICRC118WasmRegistryCanister =
           configuration: vec EnvConfig;
           dependencies: vec EnvDependency;
         };}) query;
+   /// Query the external binding for a namespace, if any.
+   get_external_binding: (namespace: text) -> (opt ExternalBinding) query;
+   get_latest_reconstitution_trace: () -> (opt ReconstitutionTrace) query;
+   get_reconstitution_traces: () -> (vec ReconstitutionTrace) query;
+   get_timer_diagnostics: () -> (TimerDiagnostics) query;
    get_tip: () -> (Tip) query;
    get_verification_progress: (wasm_id: text, audit_type: text) ->
     (vec nat) query;
@@ -480,6 +526,14 @@ type ICRC118WasmRegistryCanister =
        total: nat;
      }) query;
    list_pending_verifications: () -> (vec VerificationRecord) query;
+   /// Register an externally-deployed canister with the registry.
+   /// Caller must be a controller of the namespace.
+   /// Enforces strict 1:1 — one canister per namespace, one namespace per canister.
+   register_external_canister: (req: RegisterExternalRequest) ->
+    (variant {
+       err: RegisterExternalError;
+       ok: ExternalBinding;
+     });
    /// * [OWNER-ONLY] Manually re-triggers the deployment process for a given WASM.
    ///    * This is a utility function for debugging failed automated deployments without
    ///    * needing to re-run the entire verification and attestation lifecycle.
@@ -497,6 +551,14 @@ type ICRC118WasmRegistryCanister =
    set_search_index_canister_id: (canister_id: principal) -> (Result_1);
    set_usage_tracker_canister_id: (canister_id: principal) -> (Result_1);
    test_only_notify_indexer: (namespace: text, content: text) -> ();
+   /// Unregister an external canister binding.
+   /// Caller must be a controller of the namespace.
+   unregister_external_canister: (namespace: text, canister_id: principal) ->
+    (variant {
+       err: text;
+       ok;
+     });
+   validate_timer_state: () -> (vec text) query;
    /// Withdraw USDC or other ICRC-2 tokens from the registry treasury
    /// Only the owner can call this function
    withdraw: (ledger_id: principal, amount: nat, destination: Account) ->
@@ -608,6 +670,13 @@ type GetArchivesResultItem =
  };
 type GetArchivesResult = vec GetArchivesResultItem;
 type GetArchivesArgs = record {from: opt principal;};
+type ExternalBinding = 
+ record {
+   bound_at: nat;
+   bound_by: principal;
+   canister_id: principal;
+   namespace: text;
+ };
 type EnvDependency = 
  record {
    canister_name: text;
@@ -724,6 +793,15 @@ type CanisterType =
    metadata: ICRC16Map__2;
    repo: text;
    versions: vec CanisterVersion;
+ };
+type CancellationResult = 
+ record {
+   cancelled: vec ActionId;
+   errors: vec record {
+                 nat;
+                 text;
+               };
+   notFound: vec nat;
  };
 type BuildInfo = 
  record {
@@ -869,6 +947,22 @@ type ActionId =
  record {
    id: nat;
    time: Time;
+ };
+type ActionFilter = 
+ variant {
+   All;
+   ByActionId: nat;
+   ByRetryCount: nat;
+   ByTimeRange: record {
+                  Time;
+                  Time;
+                };
+   ByType: text;
+ };
+type ActionDetail = 
+ record {
+   ActionId;
+   Action;
  };
 type Action = 
  record {

--- a/packages/declarations/src/generated/mcp_registry/mcp_registry.did.d.ts
+++ b/packages/declarations/src/generated/mcp_registry/mcp_registry.did.d.ts
@@ -1,6 +1,6 @@
-import type { Principal } from '@dfinity/principal';
-import type { ActorMethod } from '@dfinity/agent';
-import type { IDL } from '@dfinity/candid';
+import type { Principal } from '@icp-sdk/core/principal';
+import type { ActorMethod } from '@icp-sdk/core/agent';
+import type { IDL } from '@icp-sdk/core/candid';
 
 export interface Account {
   'owner' : Principal,
@@ -16,6 +16,12 @@ export interface Action {
   'params' : Uint8Array | number[],
   'retries' : bigint,
 }
+export type ActionDetail = [ActionId, Action];
+export type ActionFilter = { 'All' : null } |
+  { 'ByActionId' : bigint } |
+  { 'ByType' : string } |
+  { 'ByTimeRange' : [Time, Time] } |
+  { 'ByRetryCount' : bigint };
 export interface ActionId { 'id' : bigint, 'time' : Time }
 export interface AppDetailsResponse {
   'gallery_images' : Array<string>,
@@ -82,7 +88,7 @@ export interface AppVersionSummary {
 }
 export interface ArchivedTransactionResponse {
   'args' : Array<TransactionRange>,
-  'callback' : GetTransactionsFn,
+  'callback' : [Principal, string],
 }
 export interface AttestationRecord {
   'audit_type' : string,
@@ -124,6 +130,11 @@ export interface BuildInfo {
   'status' : string,
   'failure_reason' : [] | [string],
   'repo_url' : [] | [string],
+}
+export interface CancellationResult {
+  'cancelled' : Array<ActionId>,
+  'errors' : Array<[bigint, string]>,
+  'notFound' : Array<bigint>,
 }
 export interface CanisterType {
   'canister_type_namespace' : string,
@@ -208,6 +219,12 @@ export interface EnvDependency {
   'canister_name' : string,
   'current_value' : [] | [Principal],
 }
+export interface ExternalBinding {
+  'bound_at' : bigint,
+  'bound_by' : Principal,
+  'canister_id' : Principal,
+  'namespace' : string,
+}
 export interface GetArchivesArgs { 'from' : [] | [Principal] }
 export type GetArchivesResult = Array<GetArchivesResultItem>;
 export interface GetArchivesResultItem {
@@ -272,9 +289,34 @@ export type GetWasmsFilter = { 'canister_type_namespace' : string } |
   { 'version_max' : [bigint, [] | [bigint], [] | [bigint]] } |
   { 'version_min' : [bigint, [] | [bigint], [] | [bigint]] };
 export interface ICRC118WasmRegistryCanister {
+  /**
+   * / * Admin method to manually trigger consensus handling for stuck bounties.
+   * /    * Use this when consensus was reached but payouts didn't happen due to bugs.
+   */
   'admin_retrigger_consensus' : ActorMethod<[string, string], Result_5>,
+  /**
+   * / * [OWNER-ONLY] Iterates through all published apps and pushes their data
+   * /    * to the search indexer to bootstrap or rebuild the index.
+   * /    *
+   * /    * NOTE: This function is designed for a small number of apps. If the registry
+   * /    * grows to hundreds or thousands of apps, this single call may exceed the
+   * /    * instruction limit and trap.
+   * /    *
+   * /    * @returns A status message indicating how many apps were successfully indexed.
+   */
   'bootstrap_search_index' : ActorMethod<[], Result_5>,
   'can_install_wasm' : ActorMethod<[Principal, string], boolean>,
+  'cancel_actions_by_filter' : ActorMethod<[ActionFilter], CancellationResult>,
+  'cancel_actions_by_ids' : ActorMethod<[Array<bigint>], CancellationResult>,
+  'clear_reconstitution_traces' : ActorMethod<[], undefined>,
+  'emergency_clear_all_timers' : ActorMethod<[], bigint>,
+  'force_release_lock' : ActorMethod<[], [] | [Time__1]>,
+  'force_system_timer_cancel' : ActorMethod<[], boolean>,
+  'get_actions_by_filter' : ActorMethod<[ActionFilter], Array<ActionDetail>>,
+  /**
+   * / * Fetches and assembles all data for an app's detail page using its stable namespace.
+   * /    * This is the single, powerful query the frontend needs.
+   */
   'get_app_details_by_namespace' : ActorMethod<
     [string, [] | [string]],
     Result_4
@@ -295,12 +337,38 @@ export interface ICRC118WasmRegistryCanister {
         }
       }
   >,
+  /**
+   * / Query the external binding for a namespace, if any.
+   */
+  'get_external_binding' : ActorMethod<[string], [] | [ExternalBinding]>,
+  'get_latest_reconstitution_trace' : ActorMethod<
+    [],
+    [] | [ReconstitutionTrace]
+  >,
+  'get_reconstitution_traces' : ActorMethod<[], Array<ReconstitutionTrace>>,
+  'get_timer_diagnostics' : ActorMethod<[], TimerDiagnostics>,
   'get_tip' : ActorMethod<[], Tip>,
   'get_verification_progress' : ActorMethod<[string, string], Array<bigint>>,
+  /**
+   * / * @notice Fetches the original verification request metadata for a given WASM ID.
+   * /    * @param wasm_id The hex-encoded SHA-256 hash of the WASM.
+   * /    * @return The optional `VerificationRequest` record, which contains the repo URL and commit hash.
+   * /    *         Returns `null` if no request is found for the given ID.
+   */
   'get_verification_request' : ActorMethod<
     [string],
     [] | [VerificationRequest]
   >,
+  /**
+   * / * Check if a verifier has already participated in the verification of a specific WASM.
+   * /    * This prevents a verifier from being assigned to multiple bounties for the same WASM.
+   * /    * Used by audit_hub during bounty reservation to enforce mutual exclusion.
+   * /    *
+   * /    * @param verifier - The principal of the verifier to check
+   * /    * @param wasm_id - The WASM hash to check participation for
+   * /    * @param audit_type - The audit type (e.g., "tools_v1", "build_reproducibility_v1")
+   * /    * @returns true if verifier has filed any audit (attestation or divergence) for this WASM+audit_type
+   */
   'has_verifier_participated_in_wasm' : ActorMethod<
     [Principal, string, string],
     boolean
@@ -344,6 +412,10 @@ export interface ICRC118WasmRegistryCanister {
     [AttestationRequest],
     AttestationResult
   >,
+  /**
+   * / * File an attestation using an API key instead of caller identity.
+   * /    * This allows verifier bots to authenticate without managing identities.
+   */
   'icrc126_file_attestation_with_api_key' : ActorMethod<
     [string, AttestationRequest],
     AttestationResult
@@ -352,6 +424,10 @@ export interface ICRC118WasmRegistryCanister {
     [DivergenceReportRequest],
     DivergenceResult
   >,
+  /**
+   * / * File a divergence report using an API key instead of caller identity.
+   * /  * This allows verifier bots to authenticate without managing identities.
+   */
   'icrc126_file_divergence_with_api_key' : ActorMethod<
     [string, DivergenceReportRequest],
     DivergenceResult
@@ -368,6 +444,24 @@ export interface ICRC118WasmRegistryCanister {
     { 'total' : bigint, 'requests' : Array<VerificationRecord> }
   >,
   'list_pending_verifications' : ActorMethod<[], Array<VerificationRecord>>,
+  /**
+   * / Register an externally-deployed canister with the registry.
+   * / Caller must be a controller of the namespace.
+   * / Enforces strict 1:1 — one canister per namespace, one namespace per canister.
+   */
+  'register_external_canister' : ActorMethod<
+    [RegisterExternalRequest],
+    { 'ok' : ExternalBinding } |
+      { 'err' : RegisterExternalError }
+  >,
+  /**
+   * / * [OWNER-ONLY] Manually re-triggers the deployment process for a given WASM.
+   * /    * This is a utility function for debugging failed automated deployments without
+   * /    * needing to re-run the entire verification and attestation lifecycle.
+   * /    *
+   * /    * @param wasm_id The hex-encoded SHA256 hash of the WASM to deploy.
+   * /    * @returns An empty Ok(()) on success, or a Text error on failure.
+   */
   'retrigger_deployment' : ActorMethod<[string], Result_1>,
   'set_auditor_credentials_canister_id' : ActorMethod<[Principal], Result_1>,
   'set_bounty_reward_amount' : ActorMethod<[bigint], Result_1>,
@@ -377,6 +471,20 @@ export interface ICRC118WasmRegistryCanister {
   'set_search_index_canister_id' : ActorMethod<[Principal], Result_1>,
   'set_usage_tracker_canister_id' : ActorMethod<[Principal], Result_1>,
   'test_only_notify_indexer' : ActorMethod<[string, string], undefined>,
+  /**
+   * / Unregister an external canister binding.
+   * / Caller must be a controller of the namespace.
+   */
+  'unregister_external_canister' : ActorMethod<
+    [string, Principal],
+    { 'ok' : null } |
+      { 'err' : string }
+  >,
+  'validate_timer_state' : ActorMethod<[], Array<string>>,
+  /**
+   * / Withdraw USDC or other ICRC-2 tokens from the registry treasury
+   * / Only the owner can call this function
+   */
   'withdraw' : ActorMethod<[Principal, bigint, Account], Result>,
 }
 export type ICRC16 = { 'Int' : bigint } |
@@ -522,6 +630,23 @@ export type ManageControllerResult = { 'Ok' : bigint } |
       { 'Generic' : string } |
       { 'Unauthorized' : null }
   };
+export interface ReconstitutionTrace {
+  'errors' : Array<string>,
+  'actionsRestored' : bigint,
+  'timestamp' : Time,
+  'migratedTo' : string,
+  'migratedFrom' : string,
+  'timersRestored' : bigint,
+  'validationPassed' : boolean,
+}
+export type RegisterExternalError = { 'NotController' : null } |
+  { 'AlreadyBound' : null } |
+  { 'NamespaceNotFound' : null } |
+  { 'CanisterAlreadyBound' : null };
+export interface RegisterExternalRequest {
+  'canister_id' : Principal,
+  'namespace' : string,
+}
 export type Result = { 'ok' : bigint } |
   { 'err' : TreasuryError };
 export type Result_1 = { 'ok' : null } |
@@ -548,6 +673,17 @@ export type Subaccount = Uint8Array | number[];
 export interface SupportedStandard { 'url' : string, 'name' : string }
 export type Time = bigint;
 export type Time__1 = bigint;
+export interface TimerDiagnostics {
+  'pendingActions' : bigint,
+  'totalActions' : bigint,
+  'overdueActions' : bigint,
+  'lockStatus' : [] | [Time],
+  'currentTime' : Time,
+  'lastExecutionDelta' : bigint,
+  'nextExecutionDelta' : [] | [bigint],
+  'systemTimerStatus' : [] | [TimerId],
+}
+export type TimerId = bigint;
 export type Timestamp = bigint;
 export interface Tip {
   'last_block_index' : Uint8Array | number[],

--- a/packages/declarations/src/generated/mcp_registry/mcp_registry.did.js
+++ b/packages/declarations/src/generated/mcp_registry/mcp_registry.did.js
@@ -27,6 +27,20 @@ export const idlFactory = ({ IDL }) => {
     'lastExecutionTime' : Time,
   });
   const Result_5 = IDL.Variant({ 'ok' : IDL.Text, 'err' : IDL.Text });
+  const ActionFilter = IDL.Variant({
+    'All' : IDL.Null,
+    'ByActionId' : IDL.Nat,
+    'ByType' : IDL.Text,
+    'ByTimeRange' : IDL.Tuple(Time, Time),
+    'ByRetryCount' : IDL.Nat,
+  });
+  const CancellationResult = IDL.Record({
+    'cancelled' : IDL.Vec(ActionId),
+    'errors' : IDL.Vec(IDL.Tuple(IDL.Nat, IDL.Text)),
+    'notFound' : IDL.Vec(IDL.Nat),
+  });
+  const Time__1 = IDL.Int;
+  const ActionDetail = IDL.Tuple(ActionId, Action);
   const AppListingStatus = IDL.Variant({
     'Rejected' : IDL.Record({ 'reason' : IDL.Text }),
     'Verified' : IDL.Null,
@@ -147,7 +161,6 @@ export const idlFactory = ({ IDL }) => {
     'timeout_date' : IDL.Opt(IDL.Nat),
     'payout_fee' : IDL.Nat,
   });
-  const Time__1 = IDL.Int;
   const AttestationRecord = IDL.Record({
     'audit_type' : IDL.Text,
     'metadata' : ICRC16Map,
@@ -308,6 +321,32 @@ export const idlFactory = ({ IDL }) => {
     'setter' : IDL.Text,
     'required' : IDL.Bool,
     'current_value' : IDL.Opt(IDL.Text),
+  });
+  const ExternalBinding = IDL.Record({
+    'bound_at' : IDL.Nat,
+    'bound_by' : IDL.Principal,
+    'canister_id' : IDL.Principal,
+    'namespace' : IDL.Text,
+  });
+  const ReconstitutionTrace = IDL.Record({
+    'errors' : IDL.Vec(IDL.Text),
+    'actionsRestored' : IDL.Nat,
+    'timestamp' : Time,
+    'migratedTo' : IDL.Text,
+    'migratedFrom' : IDL.Text,
+    'timersRestored' : IDL.Nat,
+    'validationPassed' : IDL.Bool,
+  });
+  const TimerId = IDL.Nat;
+  const TimerDiagnostics = IDL.Record({
+    'pendingActions' : IDL.Nat,
+    'totalActions' : IDL.Nat,
+    'overdueActions' : IDL.Nat,
+    'lockStatus' : IDL.Opt(Time),
+    'currentTime' : Time,
+    'lastExecutionDelta' : IDL.Int,
+    'nextExecutionDelta' : IDL.Opt(IDL.Int),
+    'systemTimerStatus' : IDL.Opt(TimerId),
   });
   const Tip = IDL.Record({
     'last_block_index' : IDL.Vec(IDL.Nat8),
@@ -558,6 +597,16 @@ export const idlFactory = ({ IDL }) => {
     'commit_hash' : IDL.Vec(IDL.Nat8),
     'wasm_hash' : IDL.Vec(IDL.Nat8),
   });
+  const RegisterExternalRequest = IDL.Record({
+    'canister_id' : IDL.Principal,
+    'namespace' : IDL.Text,
+  });
+  const RegisterExternalError = IDL.Variant({
+    'NotController' : IDL.Null,
+    'AlreadyBound' : IDL.Null,
+    'NamespaceNotFound' : IDL.Null,
+    'CanisterAlreadyBound' : IDL.Null,
+  });
   const Result_1 = IDL.Variant({ 'ok' : IDL.Null, 'err' : IDL.Text });
   const Subaccount = IDL.Vec(IDL.Nat8);
   const Account = IDL.Record({
@@ -594,6 +643,25 @@ export const idlFactory = ({ IDL }) => {
     'can_install_wasm' : IDL.Func(
         [IDL.Principal, IDL.Text],
         [IDL.Bool],
+        ['query'],
+      ),
+    'cancel_actions_by_filter' : IDL.Func(
+        [ActionFilter],
+        [CancellationResult],
+        [],
+      ),
+    'cancel_actions_by_ids' : IDL.Func(
+        [IDL.Vec(IDL.Nat)],
+        [CancellationResult],
+        [],
+      ),
+    'clear_reconstitution_traces' : IDL.Func([], [], []),
+    'emergency_clear_all_timers' : IDL.Func([], [IDL.Nat], []),
+    'force_release_lock' : IDL.Func([], [IDL.Opt(Time__1)], []),
+    'force_system_timer_cancel' : IDL.Func([], [IDL.Bool], []),
+    'get_actions_by_filter' : IDL.Func(
+        [ActionFilter],
+        [IDL.Vec(ActionDetail)],
         ['query'],
       ),
     'get_app_details_by_namespace' : IDL.Func(
@@ -633,6 +701,22 @@ export const idlFactory = ({ IDL }) => {
         ],
         ['query'],
       ),
+    'get_external_binding' : IDL.Func(
+        [IDL.Text],
+        [IDL.Opt(ExternalBinding)],
+        ['query'],
+      ),
+    'get_latest_reconstitution_trace' : IDL.Func(
+        [],
+        [IDL.Opt(ReconstitutionTrace)],
+        ['query'],
+      ),
+    'get_reconstitution_traces' : IDL.Func(
+        [],
+        [IDL.Vec(ReconstitutionTrace)],
+        ['query'],
+      ),
+    'get_timer_diagnostics' : IDL.Func([], [TimerDiagnostics], ['query']),
     'get_tip' : IDL.Func([], [Tip], ['query']),
     'get_verification_progress' : IDL.Func(
         [IDL.Text, IDL.Text],
@@ -768,6 +852,16 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(VerificationRecord)],
         ['query'],
       ),
+    'register_external_canister' : IDL.Func(
+        [RegisterExternalRequest],
+        [
+          IDL.Variant({
+            'ok' : ExternalBinding,
+            'err' : RegisterExternalError,
+          }),
+        ],
+        [],
+      ),
     'retrigger_deployment' : IDL.Func([IDL.Text], [Result_1], []),
     'set_auditor_credentials_canister_id' : IDL.Func(
         [IDL.Principal],
@@ -789,6 +883,12 @@ export const idlFactory = ({ IDL }) => {
     'set_search_index_canister_id' : IDL.Func([IDL.Principal], [Result_1], []),
     'set_usage_tracker_canister_id' : IDL.Func([IDL.Principal], [Result_1], []),
     'test_only_notify_indexer' : IDL.Func([IDL.Text, IDL.Text], [], []),
+    'unregister_external_canister' : IDL.Func(
+        [IDL.Text, IDL.Principal],
+        [IDL.Variant({ 'ok' : IDL.Null, 'err' : IDL.Text })],
+        [],
+      ),
+    'validate_timer_state' : IDL.Func([], [IDL.Vec(IDL.Text)], ['query']),
     'withdraw' : IDL.Func([IDL.Principal, IDL.Nat, Account], [Result], []),
   });
   return ICRC118WasmRegistryCanister;

--- a/packages/libs/ic-js/src/api/audit.api.ts
+++ b/packages/libs/ic-js/src/api/audit.api.ts
@@ -1193,8 +1193,6 @@ export const fileAttestationWithApiKey = async (
       `Failed to file attestation: ${JSON.stringify(result.Error)}`,
     );
   }
-
-  return result.Ok;
 };
 
 export interface ClaimBountyWithApiKeyArgs {

--- a/packages/libs/ic-js/src/api/registry.api.ts
+++ b/packages/libs/ic-js/src/api/registry.api.ts
@@ -723,3 +723,86 @@ export const downloadWasmByHash = async (
 
   return completeWasm;
 };
+
+// --- BYOC (Bring Your Own Canister) ---
+
+export interface ExternalBindingInfo {
+  canisterId: string;
+  namespace: string;
+  boundBy: string;
+  boundAt: bigint;
+}
+
+/**
+ * Register an externally-deployed canister with the Prometheus registry.
+ * Caller must be a controller of the namespace.
+ * Enforces strict 1:1 — one canister per namespace, one namespace per canister.
+ */
+export const registerExternalCanister = async (
+  identity: Identity,
+  args: { namespace: string; canisterId: string },
+): Promise<ExternalBindingInfo> => {
+  const registryActor = getRegistryActor(identity);
+
+  const result = await registryActor.register_external_canister({
+    namespace: args.namespace,
+    canister_id: Principal.fromText(args.canisterId),
+  });
+
+  if ('err' in result) {
+    const errKey = Object.keys(result.err)[0];
+    throw new Error(`Failed to register external canister: ${errKey}`);
+  }
+
+  const binding = result.ok;
+  return {
+    canisterId: binding.canister_id.toText(),
+    namespace: binding.namespace,
+    boundBy: binding.bound_by.toText(),
+    boundAt: binding.bound_at,
+  };
+};
+
+/**
+ * Unregister an external canister binding.
+ * Caller must be a controller of the namespace.
+ */
+export const unregisterExternalCanister = async (
+  identity: Identity,
+  args: { namespace: string; canisterId: string },
+): Promise<void> => {
+  const registryActor = getRegistryActor(identity);
+
+  const result = await registryActor.unregister_external_canister(
+    args.namespace,
+    Principal.fromText(args.canisterId),
+  );
+
+  if ('err' in result) {
+    throw new Error(`Failed to unregister external canister: ${result.err}`);
+  }
+};
+
+/**
+ * Query the external binding for a namespace, if any.
+ */
+export const getExternalBinding = async (
+  namespace: string,
+): Promise<ExternalBindingInfo | null> => {
+  const registryActor = getRegistryActor();
+
+  const result = await registryActor.get_external_binding(namespace);
+
+  // Candid optional: [] | [ExternalBinding]
+  if (result.length === 0) {
+    return null;
+  }
+
+  const binding = result[0];
+  return {
+    canisterId: binding.canister_id.toText(),
+    namespace: binding.namespace,
+    boundBy: binding.bound_by.toText(),
+    boundAt: binding.bound_at,
+  };
+};

--- a/skills/BYOC.md
+++ b/skills/BYOC.md
@@ -1,0 +1,89 @@
+# BYOC — Bring Your Own Canister
+
+Register an externally-deployed canister with Prometheus for discovery.
+
+## When to use
+
+You have a canister already deployed on the Internet Computer and want it discoverable through the Prometheus app store. You own the namespace in the registry.
+
+## Register
+
+```bash
+# Namespace inferred from prometheus.yml in current directory
+app-store-cli byoc register <canister-id>
+
+# Explicit namespace
+app-store-cli byoc register <canister-id> <namespace>
+```
+
+Uses your current dfx identity. You must be a controller of the namespace.
+
+## Check status
+
+```bash
+app-store-cli byoc status [namespace]
+```
+
+Anonymous query — no identity needed.
+
+## Unregister
+
+```bash
+app-store-cli byoc unregister <canister-id> [namespace]
+```
+
+## Programmatic API (ic-js)
+
+```typescript
+import {
+  registerExternalCanister,
+  unregisterExternalCanister,
+  getExternalBinding,
+} from '@prometheus-protocol/ic-js';
+
+// Register (requires identity)
+const binding = await registerExternalCanister(identity, {
+  namespace: 'com.myorg.myapp',
+  canisterId: 'rrkah-fqaaa-aaaaa-aaaaq-cai',
+});
+
+// Query (anonymous)
+const binding = await getExternalBinding('com.myorg.myapp');
+
+// Unregister (requires identity)
+await unregisterExternalCanister(identity, {
+  namespace: 'com.myorg.myapp',
+  canisterId: 'rrkah-fqaaa-aaaaa-aaaaq-cai',
+});
+```
+
+## Constraints
+
+- **Namespace ownership required** — caller must be a controller of the namespace
+- **1:1 uniqueness** — one canister per namespace, one namespace per canister
+- **Global apps only** (MVP) — no per-user or per-org scoping
+
+## Errors
+
+| Error | Meaning |
+|-------|---------|
+| `NotController` | Caller is not a controller of the namespace |
+| `NamespaceNotFound` | Namespace doesn't exist in the registry |
+| `AlreadyBound` | Namespace already has an external canister |
+| `CanisterAlreadyBound` | Canister is already bound to another namespace |
+
+## Canister API (raw Candid)
+
+| Method | Type | Auth |
+|--------|------|------|
+| `register_external_canister(req)` | update | Namespace controller |
+| `unregister_external_canister(ns, cid)` | update | Namespace controller |
+| `get_external_binding(ns)` | query | Anonymous |
+
+## File locations
+
+```
+packages/canisters/mcp_registry/src/main.mo          # Canister endpoints
+packages/libs/ic-js/src/api/registry.api.ts           # TypeScript wrappers
+packages/apps/app-store-cli/src/commands/byoc/        # CLI commands
+```


### PR DESCRIPTION
## Summary

Adds CLI and ic-js support for the BYOC (Bring Your Own Canister) feature that was already implemented in the registry backend.

### Changes

**ic-js API wrappers** (`packages/libs/ic-js/src/api/registry.api.ts`):
- `registerExternalCanister(identity, { namespace, canisterId })` — bind an external canister to a namespace
- `unregisterExternalCanister(identity, { namespace, canisterId })` — remove a binding
- `getExternalBinding(namespace)` — query binding status (anonymous)

**CLI commands** (`packages/apps/app-store-cli/src/commands/byoc/`):
- `app-store-cli byoc register <canister-id> [namespace]`
- `app-store-cli byoc unregister <canister-id> [namespace]`
- `app-store-cli byoc status [namespace]`

All commands resolve namespace from `prometheus.yml` when not provided as an argument, matching the existing CLI pattern.

**Bugfix**: Fixed pre-existing TS error in `audit.api.ts` — `fileAttestationWithApiKey` returned `result.Ok` but declared `Promise<void>`.

### Testing
- `@prometheus-protocol/declarations` ✅
- `@prometheus-protocol/ic-js` ✅  
- `app-store-cli` ✅