### PR TITLE
fix(ic-js): honor configured host in getCanisterWasmHash

### DIFF
--- a/packages/libs/ic-js/src/api/registry.api.ts
+++ b/packages/libs/ic-js/src/api/registry.api.ts
@@ -5,6 +5,7 @@ import {
   LookupPathStatus,
 } from '@icp-sdk/core/agent';
 import { getRegistryActor } from '../actors.js';
+import { getHost } from '../config.js';
 import { Registry } from '@prometheus-protocol/declarations';
 import { Principal } from '@icp-sdk/core/principal';
 import {
@@ -369,8 +370,14 @@ export const createCanisterType = async (
 export const getCanisterWasmHash = async (
   canisterId: Principal,
 ): Promise<Uint8Array | null> => {
-  const isLocal = process.env.DFX_NETWORK !== 'ic';
-  const host = isLocal ? 'http://127.0.0.1:4943' : 'https://icp-api.io';
+  // Use the host configured via `configure()` in config.ts so this function
+  // honors the CLI's `--network` flag (and any frontend's runtime config)
+  // instead of silently dialing localhost when DFX_NETWORK is unset.
+  const host = getHost();
+  const isLocal =
+    host.includes('localhost') ||
+    host.includes('127.0.0.1') ||
+    host.includes('host.docker.internal');
 
   // In v3, use HttpAgent.createSync with shouldFetchRootKey for local development
   // This will fetch the root key before the first request is made
@@ -413,11 +420,13 @@ export const getCanisterWasmHash = async (
 
     return null;
   } catch (e) {
-    console.log(e);
-    // This can happen for various reasons, e.g., network issues or if the
-    // replica is busy. We treat it as "hash not found".
+    // Surface the underlying cause so callers can diagnose the failure
+    // (wrong host, unreachable replica, canister doesn't exist, etc.) instead
+    // of getting a generic "could not read module_hash" message.
+    const reason = e instanceof Error ? e.message : String(e);
     console.warn(
-      `   ⚠️  Warning: Could not read state for canister ${canisterId.toText()}. It may not exist or the network may be busy.`,
+      `   ⚠️  Warning: Could not read state for canister ${canisterId.toText()} ` +
+        `via ${host}.\n      Reason: ${reason}`,
     );
     return null;
   }


### PR DESCRIPTION
## Summary

`getCanisterWasmHash` was reading `process.env.DFX_NETWORK` directly instead of using `getHost()` from `config.ts` like every other function in the package. Result: **BYOC registration silently dialed `http://127.0.0.1:4943` on mainnet runs**, failed, swallowed the error, and showed the misleading message "Could not read module_hash for \<canister>" — even though the canister was healthy and `dfx canister info` returned the hash immediately.

## Repro (before this PR)

```
$ app-store-cli --network ic byoc register jnyxn-waaaa-aaaab-agoda-cai io.github.jneums.app-store-scout
[CLI] Network: ic
[CLI] Host: https://icp-api.io     # ← banner says mainnet
...
[2/3] 🔎 Reading canister module hash...
   ❌ Could not read module_hash for jnyxn-waaaa-aaaab-agoda-cai.
```

Meanwhile `dfx canister --network ic info jnyxn-waaaa-aaaab-agoda-cai` returned the hash fine. The CLI was just dialing the wrong host.

## Root cause

`packages/libs/ic-js/src/api/registry.api.ts`:

```ts
// Old (broken):
const isLocal = process.env.DFX_NETWORK !== 'ic';
const host = isLocal ? 'http://127.0.0.1:4943' : 'https://icp-api.io';
```

Every other call goes through `getRegistryActor()` → `createActor()` → `getHost()`, which reads the host that was configured at CLI startup via `configureIcJs({ host })`. This function was the one outlier and only looked at an env var that the CLI doesn't set.

## Fix

1. Use `getHost()` from `config.ts` so this function honors the CLI's `--network` flag (and any frontend's runtime config). Derive `isLocal` from the resolved host, mirroring the pattern in `actors.ts createActor()`.
2. While we're in the catch, surface the underlying error reason instead of swallowing it with `console.log(e)` plus a generic "may be busy" message. Future failures will now tell you *why*.

```ts
// New:
const host = getHost();
const isLocal =
  host.includes('localhost') ||
  host.includes('127.0.0.1') ||
  host.includes('host.docker.internal');
```

## Verification

- `pnpm build` passes in `ic-js` (tsc clean)
- `pnpm test` passes in `ic-js` (16/16) and `app-store-cli` (73/73)
- End-to-end: `app-store-cli --network ic byoc register jnyxn-waaaa-aaaab-agoda-cai io.github.jneums.app-store-scout` now prints:

  ```
  [2/3] 🔎 Reading canister module hash...
     ✅ Module hash: 6489cda9a76c808a648583eac61630a0c2d2afd5215aab7d5e88fe6b8b24ed30
  ```

  …matching the on-chain hash exactly. Registration then proceeds to step 3 (any remaining failure there, e.g. `NotController`, is a separate concern unrelated to host resolution).

## Scope

Single file, ~20 lines. No behavior change for correctly-configured local callers (host still resolves to `http://127.0.0.1:4943` via `MAINNET_URL` default + explicit `configure({ host })` from the local setup). The only observable change is that mainnet callers no longer silently fall back to localhost when `DFX_NETWORK` is unset.