### PR TITLE
fix(app-store-ui): correct asset cache rule ordering so index.html revalidates

### DIFF
--- a/packages/apps/app-store-ui/assets/.ic-assets.json5
+++ b/packages/apps/app-store-ui/assets/.ic-assets.json5
@@ -1,22 +1,10 @@
+// NOTE: later rules override earlier ones for the same field, so catch-alls
+// must come first and specific overrides last.
 [
   {
-    match: 'index.html',
+    match: '**/*',
     cache: {
-      control: 'no-cache',
-    },
-    ignore: false,
-  },
-  {
-    match: 'assets/*',
-    cache: {
-      control: 'no-cache',
-    },
-    ignore: false,
-  },
-  {
-    match: '.well-known/**/*',
-    cache: {
-      control: 'no-cache',
+      max_age: 86400, // 1 day in seconds
     },
     ignore: false,
   },
@@ -28,9 +16,27 @@
     ignore: false,
   },
   {
-    match: '**/*',
+    // Vite emits content-hashed filenames here, so these are immutable.
+    match: 'assets/**/*',
     cache: {
-      max_age: 86400, // 1 day in seconds
+      max_age: 31536000, // 1 year in seconds
+    },
+    ignore: false,
+  },
+  {
+    // Entry points must always revalidate, otherwise browsers and boundary
+    // nodes keep serving a stale index.html pointing at old bundles for the
+    // full cache TTL after a deploy.
+    match: '{index.html,sw.js,workbox-*.js,manifest.webmanifest}',
+    cache: {
+      max_age: 0,
+    },
+    ignore: false,
+  },
+  {
+    match: '.well-known/**/*',
+    cache: {
+      max_age: 0,
     },
     ignore: false,
   },


### PR DESCRIPTION
## Summary

In `.ic-assets.json5`, later rules override earlier ones, so the trailing `**/*` `max_age: 86400` rule was overriding the `index.html` no-cache rule (whose `control` key is not valid dfx config anyway). Deploys therefore took up to 24h to reach browsers, which kept serving stale bundles — including the dead KongSwap code after the token registry fix in #95 shipped.

- Catch-all rules now come first; specific overrides last
- `index.html`, `sw.js`, the workbox runtime, and `manifest.webmanifest` get `max_age: 0` so every deploy is picked up on next load
- Content-hashed bundles under `assets/` are cached for 1 year (immutable filenames)

## Test plan

- [x] Already deployed to mainnet and verified: `index.html`/`sw.js` serve `cache-control: max-age=0`, hashed bundles serve `max-age=31536000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jn8NbkXeeVYf5u8qvhMP54