### PR TITLE
feat(app-store-ui): allow adding custom ICRC-2 tokens by canister ID

### DIFF
--- a/packages/apps/app-store-ui/src/components/token-manager/AddTokenDialog.tsx
+++ b/packages/apps/app-store-ui/src/components/token-manager/AddTokenDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { toast } from 'sonner';
-import { Plus, Check } from 'lucide-react';
+import { Plus, Check, Loader2, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Popover,
@@ -16,6 +16,7 @@ import {
   CommandList,
 } from '@/components/ui/command';
 import { useTokenRegistry } from '@/hooks/useTokenRegistry';
+import { useCustomTokenLookup } from '@/hooks/useCustomTokenLookup';
 import { TokenLogo } from '@/components/ui/TokenLogo';
 import { truncatePrincipal } from '@/lib/utils';
 import { cn } from '@/lib/utils';
@@ -57,6 +58,24 @@ export const AddTokenDialog: React.FC<AddTokenDialogProps> = ({
     (token) => !watchedTokenIds.includes(token.canisterId.toText()),
   );
 
+  // If the input parses as a canister principal, look it up on-chain so users
+  // can add custom tokens that aren't in the registry.
+  const {
+    principal: customPrincipal,
+    customToken,
+    isLoading: isLookingUpCustomToken,
+    error: customTokenError,
+  } = useCustomTokenLookup(searchInput);
+
+  const customTokenAlreadyWatched =
+    !!customPrincipal && watchedTokenIds.includes(customPrincipal.toText());
+  const customTokenInRegistry =
+    !!customPrincipal &&
+    availableTokens.some(
+      (token) => token.canisterId.toText() === customPrincipal.toText(),
+    );
+  const showCustomSection = !!customPrincipal && !customTokenInRegistry;
+
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
@@ -74,13 +93,70 @@ export const AddTokenDialog: React.FC<AddTokenDialogProps> = ({
             className="h-9"
           />
           <CommandList className="max-h-[300px]">
-            <CommandEmpty>
-              {isLoading
-                ? 'Loading...'
-                : searchInput.trim()
-                  ? 'No tokens found.'
-                  : 'No tokens available.'}
-            </CommandEmpty>
+            {!showCustomSection && (
+              <CommandEmpty>
+                {isLoading
+                  ? 'Loading...'
+                  : searchInput.trim()
+                    ? 'No tokens found. Paste a canister ID to add a custom token.'
+                    : 'No tokens available.'}
+              </CommandEmpty>
+            )}
+            {showCustomSection && (
+              <CommandGroup heading="Custom token">
+                {customTokenAlreadyWatched ? (
+                  <div className="flex items-center gap-2 p-3 text-sm text-muted-foreground">
+                    <Check className="h-4 w-4 shrink-0" />
+                    This token is already in your watchlist.
+                  </div>
+                ) : isLookingUpCustomToken ? (
+                  <div className="flex items-center gap-2 p-3 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Looking up canister...
+                  </div>
+                ) : customTokenError ? (
+                  <div className="flex items-start gap-2 p-3 text-sm text-muted-foreground">
+                    <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                    This canister does not respond as an ICRC-1 token ledger.
+                  </div>
+                ) : customToken && !customToken.supportsIcrc2 ? (
+                  <div className="flex items-start gap-2 p-3 text-sm text-muted-foreground">
+                    <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                    {customToken.symbol} was found, but it doesn't support
+                    ICRC-2 approvals, which this app requires.
+                  </div>
+                ) : customToken ? (
+                  <CommandItem
+                    key={customToken.canisterId.toText()}
+                    value={customToken.canisterId.toText()}
+                    onSelect={() => {
+                      onAddToken(customToken.canisterId.toText());
+                      toast.success(
+                        `${customToken.symbol} added to watchlist`,
+                      );
+                      setIsOpen(false);
+                    }}
+                    className="flex items-center gap-3 p-3">
+                    <TokenLogo
+                      token={{
+                        symbol: customToken.symbol,
+                        logo_url: customToken.logoUrl,
+                      }}
+                      size="sm"
+                    />
+                    <div className="flex-1">
+                      <div className="font-medium text-sm truncate">
+                        {customToken.name}
+                      </div>
+                      <div className="text-xs text-muted-foreground font-mono">
+                        {truncatePrincipal(customToken.canisterId.toText())}
+                      </div>
+                    </div>
+                    <Plus className="h-4 w-4 shrink-0" />
+                  </CommandItem>
+                ) : null}
+              </CommandGroup>
+            )}
             {availableTokens.length > 0 && (
               <CommandGroup>
                 {availableTokens.map((token) => (

--- a/packages/apps/app-store-ui/src/hooks/useCustomTokenLookup.ts
+++ b/packages/apps/app-store-ui/src/hooks/useCustomTokenLookup.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Principal } from '@icp-sdk/core/principal';
+import { validateTokenCanister } from '@prometheus-protocol/ic-js';
+
+/**
+ * Parses free-form search input as a canister principal and, when valid,
+ * looks the canister up on-chain to check that it is an ICRC-1 token ledger
+ * with ICRC-2 (approval) support. Used to let users add custom tokens that
+ * aren't in the token registry.
+ */
+export const useCustomTokenLookup = (searchInput: string) => {
+  const principal = useMemo(() => {
+    const trimmed = searchInput.trim();
+    // Canister IDs always contain dashes; skip lookups for plain words so we
+    // don't treat searches like "usdc" as principals.
+    if (!trimmed.includes('-')) return null;
+    try {
+      return Principal.fromText(trimmed);
+    } catch {
+      return null;
+    }
+  }, [searchInput]);
+
+  const {
+    data: customToken,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['custom-token-lookup', principal?.toText()],
+    queryFn: () => validateTokenCanister(principal!),
+    enabled: !!principal,
+    staleTime: 10 * 60 * 1000,
+    retry: false, // A non-token canister will never start responding to ICRC-1
+  });
+
+  return {
+    principal,
+    customToken: customToken ?? null,
+    isLoading: !!principal && isLoading,
+    error: error as Error | null,
+  };
+};

--- a/packages/libs/ic-js/src/api/token-watchlist.api.ts
+++ b/packages/libs/ic-js/src/api/token-watchlist.api.ts
@@ -1,10 +1,72 @@
 import { Identity } from '@icp-sdk/core/agent';
-import { getTokenWatchlistActor } from '../actors.js';
+import { getIcrcActor, getTokenWatchlistActor } from '../actors.js';
 import { TokenWatchlist } from '@prometheus-protocol/declarations';
 import { Principal } from '@icp-sdk/core/principal';
 
 export type { TokenWatchlist };
 export type WatchlistTokenInfo = TokenWatchlist.TokenInfo;
+
+export interface CustomTokenInfo {
+  canisterId: Principal;
+  symbol: string;
+  name: string;
+  decimals: number;
+  fee?: number;
+  logoUrl?: string;
+  supportsIcrc2: boolean;
+}
+
+/**
+ * Validates that a canister is an ICRC-1 token ledger and reports whether it
+ * also supports ICRC-2 (approvals). Queries the canister's own
+ * `icrc1_metadata` and `icrc1_supported_standards` endpoints.
+ *
+ * Throws if the canister does not respond to the ICRC-1 interface or its
+ * metadata is missing required fields.
+ * @param canisterId The ledger canister ID to validate.
+ */
+export const validateTokenCanister = async (
+  canisterId: Principal,
+): Promise<CustomTokenInfo> => {
+  const actor = getIcrcActor(canisterId);
+
+  const [metadata, standards] = await Promise.all([
+    actor.icrc1_metadata(),
+    actor.icrc1_supported_standards(),
+  ]);
+
+  let symbol: string | undefined;
+  let name: string | undefined;
+  let decimals: number | undefined;
+  let fee: number | undefined;
+  let logoUrl: string | undefined;
+
+  for (const [key, value] of metadata) {
+    if (key === 'icrc1:symbol' && 'Text' in value) {
+      symbol = value.Text;
+    } else if (key === 'icrc1:name' && 'Text' in value) {
+      name = value.Text;
+    } else if (key === 'icrc1:decimals' && 'Nat' in value) {
+      decimals = Number(value.Nat);
+    } else if (key === 'icrc1:fee' && 'Nat' in value) {
+      fee = Number(value.Nat);
+    } else if (key === 'icrc1:logo' && 'Text' in value) {
+      logoUrl = value.Text;
+    }
+  }
+
+  if (symbol === undefined || name === undefined || decimals === undefined) {
+    throw new Error(
+      'Token metadata is missing required fields (symbol, name, or decimals).',
+    );
+  }
+
+  const supportsIcrc2 = standards.some(
+    (standard: { name: string; url: string }) => standard.name === 'ICRC-2',
+  );
+
+  return { canisterId, symbol, name, decimals, fee, logoUrl, supportsIcrc2 };
+};
 
 /**
  * Fetches the watchlist for the authenticated user.


### PR DESCRIPTION
## Summary

The Add Token dialog only listed tokens from the registry (IC dashboard ledger index), so tokens outside it couldn't be watched — even though the `token_watchlist` canister already accepts any ICRC-1 ledger and fetches its metadata on-chain.

- **ic-js**: new `validateTokenCanister(canisterId)` helper — queries the ledger's `icrc1_metadata` and `icrc1_supported_standards`, returns symbol/name/decimals/fee/logo plus an `supportsIcrc2` flag, throws for non-ICRC-1 canisters
- **app-store-ui**: when the Add Token search input parses as a canister principal (and isn't already in the registry results), the dialog looks it up on-chain and shows a "Custom token" entry with its metadata. Distinct messages for: already in watchlist, lookup in progress, not an ICRC-1 ledger, and ICRC-1-only tokens without ICRC-2 approval support (which token allowances require — these are blocked per the requirement that tokens be ICP or ICRC-2 compatible)

## Test plan

- [x] ic-js and app-store-ui typecheck/build
- [x] Verified on-chain assumptions on mainnet: ICP ledger (`ryjl3-...`) and ckUSDC both report ICRC-2 in `icrc1_supported_standards` and expose the `icrc1:symbol/name/decimals/fee` metadata keys the helper parses
- [ ] Manual: paste a ledger canister ID (e.g. ckUSDC `xevnm-gaaaa-aaaar-qafnq-cai`) into Add Token search and add it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jn8NbkXeeVYf5u8qvhMP54